### PR TITLE
Added the page_token item to get_comment_threads querylist

### DIFF
--- a/R/get_comment_threads.R
+++ b/R/get_comment_threads.R
@@ -64,8 +64,14 @@ get_comment_threads <- function (filter = NULL, part = "snippet",
                                                       names(translate_filter))])
   names(filter)      <- yt_filter_name
 
-  querylist <- list(part = part, maxResults = max_results,
-                                                       textFormat = text_format)
+  if(is.null(page_token)){
+    querylist <- list(part = part, maxResults = max_results,
+                                 textFormat = text_format)
+  } else {
+    querylist <- list(part = part, maxResults = max_results,
+                                 textFormat = text_format,
+                                 pageToken = page_token)
+  }
   querylist <- c(querylist, filter)
 
   res <- tuber_GET("commentThreads", querylist, ...)


### PR DESCRIPTION
The page_token item was missing in the querylist. Now it is possible to load more than the first 100 comments.