### PR TITLE
Clarifying OAuth Setup

### DIFF
--- a/vignettes/tuber-ex.Rmd
+++ b/vignettes/tuber-ex.Rmd
@@ -42,7 +42,7 @@ library(tuber)
 
 ### Using the package
 
-To get going, get the application id and password from Google Developer Console (see [https://developers.google.com/youtube/v3/getting-started](https://developers.google.com/youtube/v3/getting-started)). Enable YouTube APIs. Then set the application id and password via the `yt_oauth` function. For more information about YouTube OAuth, see [YouTube OAuth Guide](https://developers.google.com/youtube/v3/guides/authentication).
+To get going, get the application id and password from Google Developer Console (see [https://developers.google.com/youtube/v3/getting-started](https://developers.google.com/youtube/v3/getting-started)). Enable YouTube APIs. Create OAuth credentials, being sure to select 'Other' as your Application Type. Then set the application id and password via the `yt_oauth` function. For more information about YouTube OAuth, see [YouTube OAuth Guide](https://developers.google.com/youtube/v3/guides/authentication).
 
 
 ```{r, eval=FALSE, auth}


### PR DESCRIPTION
Clarifying that the OAuth Application Type must be set up as 'Other' to work correctly.