### PR TITLE
Changed subsetting by position to name

### DIFF
--- a/R/get_playlist_items.R
+++ b/R/get_playlist_items.R
@@ -76,20 +76,11 @@ get_playlist_items <- function (filter = NULL, part = "contentDetails",
   }
 
   if (simplify == TRUE) {
-    if (length(res) > 5) {
-      res <- append(res, list(NA), length(res) - 1)
-      res <- plyr::ldply(lapply(
-        unlist(
-          res[seq(5, length(res), 6)],
-          recursive = FALSE),
-        as.data.frame, stringsAsFactors = FALSE)
-      )
-    } else {
-      res <- plyr::ldply(lapply(
-        unlist(res[length(res)], recursive = FALSE),
-        as.data.frame, stringsAsFactors = FALSE)
-      )
-    }
-  }
-  res
+    res <- do.call(rbind,lapply(
+      unlist(
+        res[which(names(res) == "items")],
+        recursive = FALSE),
+      as.data.frame, stringsAsFactors = FALSE)
+    )
+  }  res
 }


### PR DESCRIPTION
The previous version assumed that the items element is in the fifth position. However, the YouTube API seems to return items in the fourth position now breaking the code. This patch changes from position to name-based subsetting. I also simplified the code and removed the dependency to plyr by using base functions.