### PR TITLE
Extend and modify output of get_all_channel_video_stats()

### DIFF
--- a/R/get_all_channel_video_stats.R
+++ b/R/get_all_channel_video_stats.R
@@ -40,14 +40,21 @@ get_all_channel_video_stats <- function(channel_id = NULL, mine = FALSE, ...) {
   details <- lapply(vid_ids, get_video_details)
   res_df <- do.call(what = bind_rows, lapply(res, data.frame))
 
-  details_tot <- data.frame(id = NA, title = NA, publication_date = NA)
+  details_tot <- data.frame(id = NA, title = NA,
+                            publication_date = NA, description = NA,
+                            channelId = NA, channelTitle = NA)
 
   for (p in 1:length(details)) {
     id <- details[[p]]$items[[1]]$id
     title <- details[[p]]$items[[1]]$snippet$title
     publication_date <- details[[p]]$items[[1]]$snippet$publishedAt
+    description <- details[[p]]$items[[1]]$snippet$description
+    channelId <- details[[p]]$items[[1]]$snippet$channelId
+    channelTitle <- details[[p]]$items[[1]]$snippet$channelTitle
 
-    detail <- data.frame(id = id, title = title, publication_date = publication_date)
+    detail <- data.frame(id = id, title = title,
+                         publication_date = publication_date, description = description,
+                         channelId = channelId, channelTitle = channelTitle)
     details_tot <- rbind(detail, details_tot)
   }
 

--- a/R/get_all_channel_video_stats.R
+++ b/R/get_all_channel_video_stats.R
@@ -41,19 +41,19 @@ get_all_channel_video_stats <- function(channel_id = NULL, mine = FALSE, ...) {
   res_df <- do.call(what = bind_rows, lapply(res, data.frame))
 
   details_tot <- data.frame(id = NA, title = NA,
-                            publication_date = NA, description = NA,
+                            publishedAt = NA, description = NA,
                             channelId = NA, channelTitle = NA)
 
   for (p in 1:length(details)) {
     id <- details[[p]]$items[[1]]$id
     title <- details[[p]]$items[[1]]$snippet$title
-    publication_date <- details[[p]]$items[[1]]$snippet$publishedAt
+    publishedAt <- details[[p]]$items[[1]]$snippet$publishedAt
     description <- details[[p]]$items[[1]]$snippet$description
     channelId <- details[[p]]$items[[1]]$snippet$channelId
     channelTitle <- details[[p]]$items[[1]]$snippet$channelTitle
 
     detail <- data.frame(id = id, title = title,
-                         publication_date = publication_date, description = description,
+                         publishedAt = publishedAt, description = description,
                          channelId = channelId, channelTitle = channelTitle)
     details_tot <- rbind(detail, details_tot)
   }


### PR DESCRIPTION
Extends output of `tuber::get_all_channel_video_stats()` to include the belonging video description, channel id and channel title (commit `7fcae4d`) and renames its column `publication_date` to `publishedAt` (commit `aed854c`). Consult commit messages for further details and reasoning.

In this draft, the original camelcase name scheme is used consistently for all output columns. It is questionable, though, in how far the column names should adopt the API terminology, i.e. be named `publication_date` as previously and instead `channel_id` and `channel_title` accordingly. Maybe, `published_at` might be a less surprising change which adopts the underscore scheme, but keeps the original name as is.