### PR TITLE
Fix parameter of `get_video_details`

### DIFF
--- a/R/get_video_details.R
+++ b/R/get_video_details.R
@@ -5,7 +5,7 @@
 #'
 #' @param video_id Comma separated list of IDs of the videos for which
 #' details are requested. Required.
-#' @param part Comma-separated list of video resource properties requested.
+#' @param part Comma-separated vector of video resource properties requested.
 #' Options include:
 #' \code{contentDetails, fileDetails, id, liveStreamingDetails,
 #' localizations, player, processingDetails,
@@ -29,21 +29,32 @@
 #'
 #' get_video_details(video_id = "yJXTXN4xrI8")
 #' get_video_details(video_id = "yJXTXN4xrI8", part = "contentDetails")
+#' # retrieve multiple parameters
+#' get_video_details(video_id = "yJXTXN4xrI8", part = c("contentDetails", "status"))
+#'
 #' }
+#'
+#'
 
 get_video_details <- function(video_id = NULL, part = "snippet", ...) {
 
   if (!is.character(video_id)) stop("Must specify a video ID.")
 
+  if (!is.character(part)) stop("Parameter part must be a character vector")
+
+  if (length(part) > 1) {
+    part <- paste(part, collapse = ",")
+  }
+
   querylist <- list(part = part, id = video_id)
 
-  raw_res <- tuber_GET("videos",  querylist, ...)
+  raw_res <- tuber_GET("videos", querylist, ...)
 
   if (length(raw_res$items) == 0) {
-      warning("No details for this video are available. Likely cause:
+    warning("No details for this video are available. Likely cause:
               Incorrect ID. \n")
-      return(list())
-    }
+    return(list())
+  }
 
   raw_res
 }


### PR DESCRIPTION
- enabled a text vector as input for `part` parameter
- stop when  input parameter is not  character (list input threw a weird warning before)
- update documentation to reflect that it isn't a list that's expected (because that throws an error even in the old ).

The API supports this kind of call. see https://developers.google.com/youtube/v3/getting-started#Sample_Partial_Requests Example 1.