### PR TITLE
Only check video parameters if type is "video"

### DIFF
--- a/R/yt_search.R
+++ b/R/yt_search.R
@@ -103,15 +103,15 @@ yt_search <- function(term = NULL, max_results = 50, channel_id = NULL,
     stop("max_results only takes a value between 0 and 50.")
   }
 
-  if (!(video_license %in% c("any", "creativeCommon", "youtube"))) {
+  if (type == "video" && !(video_license %in% c("any", "creativeCommon", "youtube"))) {
     stop("video_license can only take values: any, creativeCommon, or youtube.")
   }
 
-  if (!(video_syndicated %in% c("any", "true"))) {
+  if (type == "video" && !(video_syndicated %in% c("any", "true"))) {
     stop("video_syndicated can only take values: any or true.")
   }
 
-  if (!(video_type %in% c("any", "episode", "movie"))) {
+  if (type == "video" && !(video_type %in% c("any", "episode", "movie"))) {
     stop("video_type can only take values: any, episode, or movie.")
   }
 


### PR DESCRIPTION
For video_license, video_syndicated, and video_type, only enforce the
guard clauses if the type parameter is set to "video".  The values in
these parameters are only used when `type == "video"`, otherwise the
variables are coerced to NULL before being sent to the API.

The check for `type == "video"` is required in order to prevent errors in
the guard clauses when paginating on requests with type not equal to
"video".  Since the video parameters are set to NULL when type is not
"video", if pagination is required then then call to `yt_search` for the
second page will have the video_* parameters set to NULL and cause an
error.