### PR TITLE
get_related_videos() bugfix

### DIFF
--- a/R/get_related_videos.R
+++ b/R/get_related_videos.R
@@ -51,7 +51,7 @@ get_related_videos <- function(video_id = NULL, max_results = 50,
                              "thumbnails.high.width", "thumbnails.high.height",
                              "channelTitle", "liveBroadcastContent"))
 
-  if (res$pageInfo$totalResults != 0) {
+  if (length(res$items) != 0) {
 
     rel_video_id <- sapply(res$items, function(x) unlist(x$id$videoId))
     simple_res   <- lapply(res$items, function(x) unlist(x$snippet))
@@ -65,7 +65,7 @@ get_related_videos <- function(video_id = NULL, max_results = 50,
   }
 
   # Cat total results
-  cat("Total Results", res$pageInfo$totalResults, "\n")
+  cat("Total Results", length(res$items), "\n")
 
   resdf
 }


### PR DESCRIPTION
get_related_videos() does not currently work. It throws an error:

`Error in if (res$pageInfo$totalResults != 0) { : argument is of length zero`

This is because `pageInfo` is no longer returned by the GET call. However, simply checking `length(res$items)` for the number of items returned should provide the same results and allows the function to continue working.