### PR TITLE
Fix `get_playlist_items()`

### DIFF
--- a/R/get_playlist_items.R
+++ b/R/get_playlist_items.R
@@ -78,11 +78,16 @@ get_playlist_items <- function(filter = NULL, part = "contentDetails",
   }
 
   if (simplify) {
-    allResultsList <- res$items
-    if (length(res) > 1) {
-      allResultsList <- c(allResultsList, res[-1])
-    }
-    res <- do.call(rbind.fill, lapply(allResultsList, function(x) as.data.frame(t(unlist(x)), stringsAsFactors = FALSE)))
+    allResultsList <- unlist(res[which(names(res) == "items")], recursive = FALSE)
+    allResultsList <- lapply(allResultsList, unlist)
+    res <-
+      do.call(
+        rbind.fill,
+        lapply(
+          allResultsList,
+          function(x) as.data.frame(t(x), stringsAsFactors = FALSE)
+        )
+      )
   }
 
   res


### PR DESCRIPTION
Closes #127 

This pull request restores previous behavior in `get_playlist_items()` when it is passed the argument `simplify = TRUE`.

The reprex below shows that `list_channel_videos()` and `get_playlist_items()` now return the requested number of results.

``` r
# 1. setup ----
library(tuber)
# yt_set_key()

# 2. list_channel_videos() ----
list_channel_videos(
  channel_id = "UCDgj5-mFohWZ5irWSFMFcng",
  max_results = 3,
  auth = "key"
) |> tibble::tibble()
#> # A tibble: 3 × 5
#>   kind                 etag  id    contentDetails.videoId contentDetails.video…¹
#>   <chr>                <chr> <chr> <chr>                  <chr>                 
#> 1 youtube#playlistItem Pxgm… VVVE… rK1zOcAsdXw            2023-07-02T20:35:48Z  
#> 2 youtube#playlistItem hEQN… VVVE… hXlthOM8KUE            2023-05-17T17:52:48Z  
#> 3 youtube#playlistItem wS14… VVVE… aqTM450K6jE            2023-04-16T07:20:33Z  
#> # ℹ abbreviated name: ¹​contentDetails.videoPublishedAt

# 3. get_playlist_items() ----
get_playlist_items(
  filter = c(playlist_id = "PLrEnWoR732-CN09YykVof2lxdI3MLOZda"),
  max_results = 3,
  simplify = TRUE,
  auth = "key"
) |> tibble::tibble()
#> # A tibble: 3 × 5
#>   kind                 etag  id    contentDetails.videoId contentDetails.video…¹
#>   <chr>                <chr> <chr> <chr>                  <chr>                 
#> 1 youtube#playlistItem SOz2… UExy… eliVjkSNiiU            2020-07-27T18:16:37Z  
#> 2 youtube#playlistItem e8_V… UExy… 0MLq86kTCh4            2020-07-27T17:55:52Z  
#> 3 youtube#playlistItem VS4z… UExy… -GZmDWsUSBg            2020-07-15T08:52:09Z  
#> # ℹ abbreviated name: ¹​contentDetails.videoPublishedAt
```

<sup>Created on 2023-07-04 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>