### PR TITLE
Fix handling of missing replies in comments

### DIFF
--- a/R/get_all_comments.R
+++ b/R/get_all_comments.R
@@ -62,8 +62,9 @@ process_page <- function(res = NULL) {
     
     if (!is.null(comment$replies) && "comments" %in% names(comment$replies)) {
       reply_items <- comment$replies$comments
-      
-      if (!is.null(reply_items) && length(reply_items) > 0) {
+      n_replies <- if (is.null(reply_items)) 0 else length(reply_items)
+
+      if (n_replies > 0) {
         reply_data <- lapply(reply_items, function(reply) {
           reply_snippet <- reply$snippet
           reply_id <- reply$id

--- a/tests/testthat/test-get-all-comments.R
+++ b/tests/testthat/test-get-all-comments.R
@@ -1,0 +1,30 @@
+context("Get All Comments")
+
+test_that("process_page handles comments with and without replies", {
+  # Construct sample API response
+  res <- list(
+    items = list(
+      list(
+        id = "c1",
+        snippet = list(topLevelComment = list(snippet = list(textDisplay = "t1"))),
+        replies = list(comments = list(
+          list(id = "c1r1", snippet = list(textDisplay = "r1")),
+          list(id = "c1r2", snippet = list(textDisplay = "r2"))
+        ))
+      ),
+      list(
+        id = "c2",
+        snippet = list(topLevelComment = list(snippet = list(textDisplay = "t2")))
+        # No replies
+      )
+    )
+  )
+
+  df <- tuber:::process_page(res)
+
+  expect_s3_class(df, "data.frame")
+  expect_true(any(is.na(df$parentId)))    # top level comments
+  expect_true(any(!is.na(df$parentId)))   # replies present
+  expect_true("c2" %in% df$id)            # second comment present
+  expect_false(any(df$parentId == "c2"))  # no replies for c2
+})


### PR DESCRIPTION
## Summary
- handle `NULL` reply lists in `process_page()`
- add unit test to ensure comments without replies are handled

## Testing
- `R CMD check --no-manual --as-cran .` *(fails: `R` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eca380bc8832f88656559e1f27e73