### PR TITLE
Update OAuth docs

### DIFF
--- a/R/yt_oauth.R
+++ b/R/yt_oauth.R
@@ -6,6 +6,11 @@
 #' to TRUE. By default, it is set to FALSE.
 #' The function launches a browser to allow you to authorize the application
 #'
+#' If a browser cannot be opened, pass \code{use_oob = TRUE} to
+#' \code{yt_oauth()} so authentication can be completed using an
+#' out-of-band code.
+#' Delete the \code{.httr-oauth} file in the working directory to force
+#' re-authentication.
 #' @param app_id client id; required; no default
 #' @param app_secret client secret; required; no default
 #' @param scope Character. \code{ssl}, \code{basic},

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ Guide](https://developers.google.com/youtube/v3/guides/authentication).
 yt_oauth("app_id", "app_password")
 ```
 
+If your session cannot open a browser window for authentication, pass
+`use_oob = TRUE` to `yt_oauth()` so that authentication can be completed
+via an out-of-band code.
+
+To force re-authentication at any time, delete the `.httr-oauth` file in
+your working directory.
+
 **Note:** If you are on ubuntu, you may have to run the following before
 doing anything:
 

--- a/man/yt_oauth.Rd
+++ b/man/yt_oauth.Rd
@@ -40,6 +40,8 @@ doesn't find it, it expects an application ID and a secret.
 If you want to remove the existing \code{.httr-oauth}, set remove_old_oauth
 to TRUE. By default, it is set to FALSE.
 The function launches a browser to allow you to authorize the application
+If a browser cannot be opened, pass \code{use_oob = TRUE} to \code{yt_oauth()} so authentication can be completed using an out-of-band code.
+Delete the \code{.httr-oauth} file in the working directory to force re-authentication.
 }
 \examples{
  \dontrun{


### PR DESCRIPTION
## Summary
- mention out-of-band authentication in README and yt_oauth documentation
- explain how to delete `.httr-oauth` to re-authenticate

## Testing
- `R -q -e 'devtools::test()'` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686eca17dd18832f977b46c833b8d9ad