### PR TITLE
Refactor get_comment_threads retrieval loop

### DIFF
--- a/tests/testthat/test-get-comment-threads.R
+++ b/tests/testthat/test-get-comment-threads.R
@@ -1,0 +1,21 @@
+context("Comment Threads")
+
+test_that("get_comment_threads returns all comments", {
+  skip_on_cran()
+  google_token <- readRDS("token_file.rds.enc")$google_token
+  options(google_token = google_token)
+
+  first_page <- tuber_GET(
+    "commentThreads",
+    list(part = "snippet", videoId = "N708P-A45D0", maxResults = 100)
+  )
+  total <- first_page$pageInfo$totalResults
+
+  all_comments <- get_comment_threads(
+    filter = c(video_id = "N708P-A45D0"),
+    max_results = 101
+  )
+
+  expect_s3_class(all_comments, "data.frame")
+  expect_equal(nrow(all_comments), total)
+})


### PR DESCRIPTION
## Summary
- remove recursive get_comment_threads calls
- iteratively fetch comment thread pages via `tuber_GET`
- deduplicate results before returning
- add regression test for comment thread counts

## Testing
- `R -q -e "library(testthat); testthat::test_dir('tests/testthat')"`

------
https://chatgpt.com/codex/tasks/task_e_686eca0dda84832fb983b26b2bbfa6f3