### PR TITLE
Handle get_all_comments with no comments

### DIFF
--- a/R/get_all_comments.R
+++ b/R/get_all_comments.R
@@ -26,6 +26,10 @@
 get_all_comments <- function(video_id = NULL, ...) {
   querylist <- list(videoId = video_id, part = "id,replies,snippet")
   res <- tuber_GET("commentThreads", query = querylist, ...)
+  if (length(res$items) == 0) {
+    message("No comments found for this video.")
+    return(data.frame())
+  }
   agg_res <- process_page(res)
   page_token <- res$nextPageToken
 

--- a/tests/testthat/test-get-all-comments.R
+++ b/tests/testthat/test-get-all-comments.R
@@ -1,0 +1,14 @@
+context("Get All Comments")
+
+test_that("get_all_comments handles videos with no comments", {
+  skip_on_cran()
+  google_token <- readRDS("token_file.rds.enc")$google_token
+  options(google_token = google_token)
+
+  expect_message(
+    res <- get_all_comments(video_id = "XqZsoesa55w"),
+    "No comments found"
+  )
+  expect_s3_class(res, "data.frame")
+  expect_equal(nrow(res), 0L)
+})


### PR DESCRIPTION
## Summary
- return early when a video has no comments
- test for comment-less videos

## Testing
- `Rscript -e 'library(testthat); testthat::test_dir("tests/testthat")'` *(fails: there is no package called 'testthat')*

------
https://chatgpt.com/codex/tasks/task_e_686eca0b4e4c832f9bb9f823dd408c48