### PR TITLE
Improve channel stats pagination

### DIFF
--- a/man/get_all_channel_video_stats.Rd
+++ b/man/get_all_channel_video_stats.Rd
@@ -14,15 +14,11 @@ get_all_channel_video_stats(channel_id = NULL, mine = FALSE, ...)
 \item{\dots}{Additional arguments passed to \code{\link{tuber_GET}}.}
 }
 \value{
-nested named list with top element names:
-\code{kind, etag, id,}
-\code{snippet (list of details of the channel including title)}
-\code{, statistics (list of 5)}
-
+A data.frame containing video metadata and statistics.
 If the \code{channel_id} is mistyped or there is no information, an empty list is returned
 }
 \description{
-Get statistics on all the videos in a Channel
+Get statistics on all the videos in a Channel. Iterates through the uploads playlist and collects video IDs from all pages before fetching statistics for each video.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
## Summary
- iterate through all playlist pages in `get_all_channel_video_stats`
- clarify docs for `get_all_channel_video_stats`

## Testing
- `Rscript -e "devtools::test()"` *(fails: there is no package called 'devtools')*

------
https://chatgpt.com/codex/tasks/task_e_686eca073088832f9e7773965f8b7088