### PR TITLE
Allow passing extra playlist search params

### DIFF
--- a/R/get_playlists.R
+++ b/R/get_playlists.R
@@ -19,6 +19,7 @@
 #' the function returns a \code{data.frame}. Else a list with all the
 #' information returned.
 #' @param \dots Additional arguments passed to \code{\link{tuber_GET}}.
+#'   Can be used to pass extra search parameters such as \code{q}.
 #'
 #' @return playlists
 #' When \code{simplify} is \code{TRUE}, a \code{data.frame} with 4
@@ -35,6 +36,7 @@
 #'
 #' get_playlists(filter=c(channel_id="UCMtFAi84ehTSYSE9XoHefig"))
 #' get_playlists(filter=c(channel_id="UCMtFAi84ehTSYSE9X")) # incorrect Channel ID
+#' get_playlists(filter=c(channel_id="UCMtFAi84ehTSYSE9XoHefig"), q = "keyword")
 #' }
 
 get_playlists <- function(filter = NULL,
@@ -61,7 +63,7 @@ get_playlists <- function(filter = NULL,
 
   querylist <- list(part = part, maxResults = max_results,
                     pageToken = page_token, hl = hl)
-  querylist <- c(querylist, filter)
+  querylist <- c(querylist, filter, ...)
 
   raw_res <- tuber_GET("playlists", querylist, ...)
 

--- a/man/get_playlists.Rd
+++ b/man/get_playlists.Rd
@@ -38,7 +38,8 @@ optional}
 the function returns a \code{data.frame}. Else a list with all the
 information returned.}
 
-\item{\dots}{Additional arguments passed to \code{\link{tuber_GET}}.}
+\item{\dots}{Additional arguments passed to \code{\link{tuber_GET}}.
+Can be used to pass extra search parameters such as \code{q}.}
 }
 \value{
 playlists
@@ -56,6 +57,7 @@ Get Playlists
 
 get_playlists(filter=c(channel_id="UCMtFAi84ehTSYSE9XoHefig"))
 get_playlists(filter=c(channel_id="UCMtFAi84ehTSYSE9X")) # incorrect Channel ID
+get_playlists(filter=c(channel_id="UCMtFAi84ehTSYSE9XoHefig"), q = "keyword")
 }
 }
 \references{

--- a/tests/testthat/test-get-playlists.R
+++ b/tests/testthat/test-get-playlists.R
@@ -1,0 +1,11 @@
+context("Get Playlists")
+
+test_that("get_playlists accepts q parameter", {
+  skip_on_cran()
+
+  google_token <- readRDS("token_file.rds.enc")$google_token
+  options(google_token = google_token)
+
+  res <- get_playlists(filter = c(channel_id = "UCMtFAi84ehTSYSE9XoHefig"), q = "music")
+  expect_true(is.list(res))
+})


### PR DESCRIPTION
## Summary
- add `...` into the query list before calling `tuber_GET`
- document how to send extra parameters like `q`
- test passing `q` to `get_playlists`

## Testing
- `Rscript -e "devtools::test()"` *(fails: unknown input format for test token)*

------
https://chatgpt.com/codex/tasks/task_e_686eca140b68832f8635c01d86785a79