### PR TITLE
Improve yt_search pagination handling

### DIFF
--- a/R/yt_search.R
+++ b/R/yt_search.R
@@ -232,19 +232,25 @@ yt_search <- function(term = NULL, max_results = 50, channel_id = NULL,
   page_token <- res$nextPageToken
   page_count <- 1
   total_returned <- nrow(all_results)
+  items_returned <- total_returned
 
   # Get all pages up to max_pages limit and requested max_results
   while (!is.null(page_token) && page_count < max_pages &&
-         total_returned < max_results) {
+         items_returned < max_results) {
     querylist$pageToken <- page_token
     querylist$maxResults <- min(max_results - total_returned, 50)
     a_res <- tuber_GET("search", querylist, ...)
 
     next_results <- process_results(a_res$items, type)
     all_results <- rbind(all_results, next_results)
+    items_returned <- items_returned + nrow(next_results)
     total_returned <- nrow(all_results)
     page_token <- a_res$nextPageToken
     page_count <- page_count + 1
+
+    if (items_returned >= max_results) {
+      break
+    }
 
     # Check if we've reached YouTube's limit (around 500-600 items)
     if (nrow(all_results) >= 500 && is.null(page_token)) {

--- a/tests/testthat/test-yt-search.R
+++ b/tests/testthat/test-yt-search.R
@@ -9,3 +9,13 @@ test_that("yt_search obeys max_results", {
   expect_s3_class(res, "data.frame")
   expect_equal(nrow(res), 5)
 })
+
+test_that("yt_search returns exactly five channel results", {
+  skip_on_cran()
+  google_token <- readRDS("token_file.rds.enc")$google_token
+  options(google_token = google_token)
+
+  res <- yt_search(term = "news", type = "channel", max_results = 5)
+  expect_s3_class(res, "data.frame")
+  expect_equal(nrow(res), 5)
+})


### PR DESCRIPTION
## Summary
- track number of items returned while fetching pages
- stop requesting pages once `max_results` items are retrieved
- test that searches for channels return exactly five rows

## Testing
- `R -q -e 'devtools::test()'` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ed52fc5d4832fa37291866385bf10