### PR TITLE
Fix playlist items pagination

### DIFF
--- a/R/get_playlist_items.R
+++ b/R/get_playlist_items.R
@@ -65,20 +65,19 @@ get_playlist_items <- function(filter = NULL, part = "contentDetails",
   res <- tuber_GET(path = "playlistItems",
                    query = querylist,
                    ...)
-  items <- res$items
   next_token <- res$nextPageToken
 
-  while (length(items) < max_results && is.character(next_token)) {
+  while (length(res$items) < max_results && is.character(next_token)) {
     querylist$pageToken <- next_token
-    querylist$maxResults <- min(50, max_results - length(items))
+    querylist$maxResults <- min(50, max_results - length(res$items))
     a_res <- tuber_GET(path = "playlistItems",
                        query = querylist,
                        ...)
-    items <- c(items, a_res$items)
+    res$items <- c(res$items, a_res$items)
     next_token <- a_res$nextPageToken
   }
 
-  res$items <- items
+  res$nextPageToken <- next_token
 
   if (simplify) {
     allResultsList <- unlist(res[which(names(res) == "items")], recursive = FALSE)

--- a/tests/testthat/test-get-playlist-items.R
+++ b/tests/testthat/test-get-playlist-items.R
@@ -1,0 +1,10 @@
+context("Get Playlist Items")
+
+test_that("get_playlist_items returns >50 results when requested", {
+  skip_on_cran()
+  google_token <- readRDS("token_file.rds.enc")$google_token
+  options(google_token = google_token)
+
+  res <- get_playlist_items(filter = c(playlist_id = "PLrEnWoR732-CN09YykVof2lxdI3MLOZda"), max_results = 55)
+  expect_true(length(res$items) >= 55)
+})


### PR DESCRIPTION
## Summary
- fix playlist items loop to append to res$items and retain nextPageToken
- add regression test for retrieving >50 playlist items

## Testing
- `Rscript -e 'library(testthat); test_dir("tests/testthat")'` *(fails: there is no package called 'testthat')*

------
https://chatgpt.com/codex/tasks/task_e_686ed56bbccc832f95dc43fb61dcb5fa