### PR TITLE
Fix OAuth token extraction from httr saved format

### DIFF
--- a/R/yt_oauth.R
+++ b/R/yt_oauth.R
@@ -60,7 +60,12 @@ yt_oauth <- function(app_id = NULL, app_secret = NULL, scope = "ssl", token = ".
   google_token <- NULL
   if (file.exists(token)) {
     google_token <- tryCatch({
-      suppressWarnings(readRDS(token))
+      saved_token <- suppressWarnings(readRDS(token))
+      # httr saves tokens in a list with hash as key - extract the actual token
+      if (is.list(saved_token) && !inherits(saved_token, "Token")) {
+        saved_token <- saved_token[[1]]
+      }
+      saved_token
     }, error = function(e) {
       warn("Unable to read existing OAuth token",
            token_file = token,


### PR DESCRIPTION
## Summary

httr's `oauth2.0_token` saves tokens as a list with a hash key, but `yt_oauth` was using the list directly instead of extracting the `Token2.0` object. This caused "attempt to apply non-function" errors when making API calls with a previously saved token.

## The Problem

When a token is saved with `saveRDS()` and later loaded, httr wraps it in a list structure:
```r
# Token gets saved as:
list("abc123hash" = <Token2.0 object>)
```

The existing code passed this list wrapper to `options(google_token = ...)`, but API calls expect the actual Token object.

## The Fix

Extract `token[[1]]` when the loaded object is a list wrapper rather than a Token object:
```r
if (is.list(saved_token) && !inherits(saved_token, "Token")) {
  saved_token <- saved_token[[1]]
}
```

## Test Plan

- [x] Tested with saved OAuth tokens from multiple YouTube channels
- [x] Verified token refresh works correctly
- [x] Confirmed `upload_video()` and other API calls work with loaded tokens