### PR TITLE
Fix five request-assembly defects, including two functions that could never issue a request

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,32 @@
+# version 1.4.0.9000 (development)
+
+## Bug fixes
+
+* `list_videocats()` and `list_guidecats()` appended the translated filter to
+  the query list as an unnamed element, so the query contained an unnamed
+  component. Both `httr` and `httr2` reject such a query ("All components of
+  query must be named"), so neither function could issue a request at all. The
+  filter is now merged by name, and `regionCode`/`id` reach the API.
+
+* `list_videocats()` indexed its filter with `filter$regionCode`. `filter` is a
+  named character vector, so this raised "$ operator is invalid for atomic
+  vectors" on every call. `list_guidecats()` failed the same way when
+  assembling its result: with no items it raised "replacement has 1 row, data
+  has 0", and with items it returned a list rather than the documented
+  `data.frame`. Both now index by name and return a `data.frame` in every case.
+
+* `get_comments()` documented and validated a `page_token` argument but never
+  placed it in the query, so paging through replies with a `parent_id` filter
+  always returned the first page. It is now sent as `pageToken`.
+
+* `list_regions()` and `list_abuse_report_reasons()` documented and validated an
+  `hl` argument that never reached the query. Both `i18nRegions.list` and
+  `videoAbuseReportReasons.list` support `hl`, and the sibling `list_langs()`
+  already sent it. It is now sent.
+
+* `get_live_streams()` sent its `status` filter as `eventType`, which is a
+  `search.list` parameter. `liveBroadcasts.list` filters on `broadcastStatus`.
+
 # version 1.4.0
 
 ## Major API Coverage Enhancements (Closing the Gap)

--- a/R/extended_endpoints.R
+++ b/R/extended_endpoints.R
@@ -75,7 +75,9 @@ get_live_streams <- function(stream_id = NULL,
   }
 
   if (!is.null(status)) {
-    query$eventType <- status
+    # liveBroadcasts.list filters on broadcastStatus; eventType belongs to
+    # search.list and is ignored here.
+    query$broadcastStatus <- status
   }
 
   # Make API call

--- a/R/get_comments.R
+++ b/R/get_comments.R
@@ -71,7 +71,7 @@ get_comments <- function(filter = NULL, part = "snippet", max_results = 100,
   names(filter)      <- yt_filter_name
 
   querylist <- list(part = part, maxResults = max_results,
-                    textFormat = text_format)
+                    textFormat = text_format, pageToken = page_token)
   querylist <- c(querylist, filter)
 
   raw_res <- tuber_GET("comments", querylist, ...)

--- a/R/list_abuse_report_reasons.R
+++ b/R/list_abuse_report_reasons.R
@@ -33,7 +33,7 @@ list_abuse_report_reasons <- function(part = "id, snippet", hl = "en-US", ...) {
   assert_character(part, len = 1, min.chars = 1, .var.name = "part")
   assert_character(hl, len = 1, min.chars = 1, .var.name = "hl")
 
-  querylist <- list(part = part)
+  querylist <- list(part = part, hl = hl)
 
   res <- tuber_GET("videoAbuseReportReasons", querylist, ...)
 

--- a/R/list_guidecats.R
+++ b/R/list_guidecats.R
@@ -44,7 +44,7 @@ list_guidecats <- function(filter = NULL, hl = NULL, ...) {
   yt_filter_name <- translate_filter[names(filter)]
   names(filter) <- yt_filter_name
 
-  querylist <- list(part = "snippet", hl = hl, filter)
+  querylist <- c(list(part = "snippet", hl = hl), as.list(filter))
 
   res <- tuber_GET("guideCategories", querylist, ...)
 
@@ -58,13 +58,17 @@ list_guidecats <- function(filter = NULL, hl = NULL, ...) {
   # Cat total results
   cat("Total Number of Categories:", length(res$items), "\n")
 
+  # `filter` is a named character vector, so it must be indexed by name. A
+  # category_id filter carries no region, which yields NA.
+  region_code <- unname(filter["regionCode"])
+
   if (length(res$items) > 0) {
     simple_res <- lapply(res$items, function(x)
-      c(unlist(x$snippet), etag = x$etag, id = x$id))
-    resdf <- do.call(rbind, simple_res)
-    resdf$region_code <- filter["regionCode"]
-  } else {
-    resdf$region_code <- filter["regionCode"]
+      as.data.frame(t(c(unlist(x$snippet), etag = x$etag, id = x$id)),
+                    stringsAsFactors = FALSE))
+    resdf <- bind_rows(simple_res)
+    resdf$region_code <- region_code
+    resdf <- resdf[, union("region_code", names(resdf)), drop = FALSE]
   }
 
   resdf

--- a/R/list_regions.R
+++ b/R/list_regions.R
@@ -27,7 +27,7 @@ list_regions <- function(hl = NULL, ...) {
     assert_character(hl, len = 1, min.chars = 1, .var.name = "hl")
   }
 
-  querylist <- list(part = "snippet")
+  querylist <- list(part = "snippet", hl = hl)
 
   res <- tuber_GET("i18nRegions", querylist, ...)
 

--- a/R/list_videocats.R
+++ b/R/list_videocats.R
@@ -34,14 +34,18 @@ list_videocats <- function(filter = NULL, ...) {
   yt_filter_name <- translate_filter[names(filter)]
   names(filter) <- yt_filter_name
 
-  querylist <- list(part = "snippet", filter)
+  querylist <- c(list(part = "snippet"), as.list(filter))
 
   res <- tuber_GET("videoCategories", querylist, ...)
 
   # Cat total results
   cat("Total Number of Categories:", length(res$items), "\n")
 
-  resdf <- data.frame(region_code = filter$regionCode,
+  # `filter` is a named character vector, so it must be indexed by name. A
+  # category_id filter carries no region, which yields NA.
+  region_code <- unname(filter["regionCode"])
+
+  resdf <- data.frame(region_code = character(),
                       channelId = character(),
                       title = character(),
                       assignable = logical(),
@@ -51,10 +55,13 @@ list_videocats <- function(filter = NULL, ...) {
 
   if (length(res$items) > 0) {
     simple_res <- lapply(res$items, function(x) {
-      c(unlist(x$snippet), etag = x$etag, id = x$id)
+      as.data.frame(t(c(unlist(x$snippet), etag = x$etag, id = x$id)),
+                    stringsAsFactors = FALSE)
     })
 
-    resdf <- rbind(resdf, do.call(rbind, simple_res))
+    resdf <- bind_rows(simple_res)
+    resdf$region_code <- region_code
+    resdf <- resdf[, union("region_code", names(resdf)), drop = FALSE]
   }
 
   resdf

--- a/tests/testthat/test-request-assembly.R
+++ b/tests/testthat/test-request-assembly.R
@@ -1,0 +1,129 @@
+# Offline tests that assert on the request tuber assembles, and on the
+# post-processing of a canned response. The HTTP layer is mocked, so these
+# never touch the network.
+
+# Build a tuber_GET stand-in that records every (path, query) it is handed and
+# returns a canned response. `$reqs` holds the captured requests afterwards.
+new_capture <- function(response) {
+  captured <- new.env(parent = emptyenv())
+  captured$reqs <- list()
+  captured$fn <- function(path, query, ...) {
+    captured$reqs[[length(captured$reqs) + 1L]] <- list(path = path, query = query)
+    response
+  }
+  captured
+}
+
+# A videoCategories/guideCategories style response with `n` items.
+cat_items <- function(n) {
+  list(items = lapply(seq_len(n), function(i) {
+    list(etag = "etag1", id = as.character(i),
+         snippet = list(channelId = "UCchannel",
+                        title = paste("Category", i),
+                        assignable = TRUE))
+  }))
+}
+
+test_that("every query component tuber builds is named", {
+  # httr and httr2 both reject a query list containing an unnamed element, so
+  # an unnamed component means the request can never be sent.
+  expect_query_named <- function(reqs) {
+    for (r in reqs) {
+      nms <- names(r$query)
+      expect_false(is.null(nms))
+      expect_true(all(nzchar(nms)),
+                  info = paste("unnamed query component for path", r$path))
+    }
+  }
+
+  cap <- new_capture(cat_items(2))
+  local_mocked_bindings(tuber_GET = cap$fn, .package = "tuber")
+  try(list_videocats(c(region_code = "JP")), silent = TRUE)
+  try(list_guidecats(c(region_code = "JP")), silent = TRUE)
+  expect_gt(length(cap$reqs), 0)
+  expect_query_named(cap$reqs)
+})
+
+test_that("list_videocats sends regionCode and returns a data.frame", {
+  cap <- new_capture(cat_items(2))
+  local_mocked_bindings(tuber_GET = cap$fn, .package = "tuber")
+  res <- list_videocats(c(region_code = "JP"))
+  expect_s3_class(res, "data.frame")
+  expect_equal(nrow(res), 2)
+  expect_true(all(res$region_code == "JP"))
+  expect_length(cap$reqs, 1)
+  expect_equal(cap$reqs[[1]]$path, "videoCategories")
+  expect_equal(cap$reqs[[1]]$query$regionCode, "JP")
+})
+
+test_that("list_videocats with a category_id filter sends id", {
+  cap <- new_capture(cat_items(1))
+  local_mocked_bindings(tuber_GET = cap$fn, .package = "tuber")
+  list_videocats(c(category_id = "10"))
+  expect_equal(cap$reqs[[1]]$query$id, "10")
+})
+
+test_that("list_guidecats sends regionCode and hl, and returns a data.frame", {
+  cap <- new_capture(cat_items(2))
+  local_mocked_bindings(tuber_GET = cap$fn, .package = "tuber")
+  res <- list_guidecats(c(region_code = "JP"), hl = "ja")
+  expect_s3_class(res, "data.frame")
+  expect_equal(nrow(res), 2)
+  expect_length(cap$reqs, 1)
+  expect_equal(cap$reqs[[1]]$path, "guideCategories")
+  expect_equal(cap$reqs[[1]]$query$regionCode, "JP")
+  expect_equal(cap$reqs[[1]]$query$hl, "ja")
+})
+
+test_that("list_guidecats returns an empty data.frame when there are no items", {
+  cap <- new_capture(cat_items(0))
+  local_mocked_bindings(tuber_GET = cap$fn, .package = "tuber")
+  res <- list_guidecats(c(region_code = "ZZ"))
+  expect_s3_class(res, "data.frame")
+  expect_equal(nrow(res), 0)
+})
+
+test_that("get_comments forwards page_token as pageToken", {
+  # comments.list documents a pageToken parameter; without it, paging through
+  # replies with a parent_id filter always returns the first page.
+  cap <- new_capture(list(items = list()))
+  local_mocked_bindings(tuber_GET = cap$fn, .package = "tuber")
+  suppressWarnings(get_comments(filter = c(parent_id = "P1"), page_token = "TOKEN123"))
+  expect_equal(cap$reqs[[1]]$query$pageToken, "TOKEN123")
+})
+
+test_that("get_comments omits pageToken when none is given", {
+  cap <- new_capture(list(items = list()))
+  local_mocked_bindings(tuber_GET = cap$fn, .package = "tuber")
+  suppressWarnings(get_comments(filter = c(parent_id = "P1")))
+  expect_null(cap$reqs[[1]]$query$pageToken)
+})
+
+test_that("list_regions forwards hl", {
+  # i18nRegions.list documents an hl parameter; the sibling list_langs() sends it.
+  cap <- new_capture(list(items = list()))
+  local_mocked_bindings(tuber_GET = cap$fn, .package = "tuber")
+  list_regions(hl = "fr")
+  expect_equal(cap$reqs[[1]]$path, "i18nRegions")
+  expect_equal(cap$reqs[[1]]$query$hl, "fr")
+})
+
+test_that("list_abuse_report_reasons forwards hl", {
+  # videoAbuseReportReasons.list documents an hl parameter.
+  cap <- new_capture(list(items = list()))
+  local_mocked_bindings(tuber_GET = cap$fn, .package = "tuber")
+  list_abuse_report_reasons(hl = "fr")
+  expect_equal(cap$reqs[[1]]$path, "videoAbuseReportReasons")
+  expect_equal(cap$reqs[[1]]$query$hl, "fr")
+})
+
+test_that("get_live_streams sends the status filter as broadcastStatus", {
+  # liveBroadcasts.list has no eventType parameter; the documented filter for
+  # broadcast state is broadcastStatus.
+  cap <- new_capture(list(items = list()))
+  local_mocked_bindings(tuber_GET = cap$fn, .package = "tuber")
+  get_live_streams(stream_id = "S1", status = "completed")
+  expect_equal(cap$reqs[[1]]$path, "liveBroadcasts")
+  expect_equal(cap$reqs[[1]]$query$broadcastStatus, "completed")
+  expect_null(cap$reqs[[1]]$query$eventType)
+})


### PR DESCRIPTION
Five request-assembly defects, found by an offline audit that stubbed the HTTP layer and
asserted on the exact query each function builds. No API key is needed to reproduce any of
them. Each fix ships with a test confirmed to fail without it.

The dominant bug class here is the one that matters most for an API client: **an argument
the documentation describes, that never reaches the request.**

## 1. `list_videocats()` and `list_guidecats()` could not issue a request at all

Both built their query as `list(part = "snippet", hl = hl, filter)`. `filter` is a named
character vector, so this places it as a single **unnamed** list element rather than
splicing its named entries in:

```r
filter <- c(regionCode = "US")

list(part = "snippet", filter)          # old
#> $part
#> [1] "snippet"
#> [[2]]
#> regionCode
#>       "US"                            <- unnamed component

c(list(part = "snippet"), as.list(filter))   # new
#> $part
#> [1] "snippet"
#> $regionCode
#> [1] "US"
```

Both `httr` and `httr2` reject a query with an unnamed component ("All components of query
must be named"), so neither function could reach the API. `regionCode` and `id` now arrive.

## 2. The same two functions indexed an atomic vector with `$`

`list_videocats()` used `filter$regionCode`. On a named character vector that is an error,
not a lookup:

```r
c(regionCode = "US")$regionCode
#> Error: $ operator is invalid for atomic vectors
```

`list_guidecats()` failed the same way when assembling its result: with no items it raised
"replacement has 1 row, data has 0", and with items it returned a list rather than the
documented `data.frame`. Both now index by name and return a `data.frame` in every case.

## 3. `get_comments()` never sent `page_token`

The argument is documented and validated, and then never placed in the query. Paging through
replies with a `parent_id` filter always returned the first page. Now sent as `pageToken`.

## 4. `list_regions()` and `list_abuse_report_reasons()` never sent `hl`

Both document and validate an `hl` argument that never reached the query. Both
`i18nRegions.list` and `videoAbuseReportReasons.list` support `hl`, and the sibling
`list_langs()` already sent it, so the omission is inconsistent within the package as well as
with the API.

## 5. `get_live_streams()` sent the wrong parameter name

It sent its `status` filter as `eventType`, which is a `search.list` parameter.
`liveBroadcasts.list` filters on `broadcastStatus`. Parameter names were checked against the
current YouTube Data API documentation rather than from memory.

## How this was verified without credentials

The HTTP layer was stubbed so each function's assembled URL and query could be captured and
asserted offline. That is what makes "this argument never reaches the request" a mechanical
check rather than a guess, and it is why these are reproducible by any reviewer without a
key.

**What could not be verified**: whether the API's *responses* are parsed correctly, since
that needs live calls. This branch changes request assembly only; response handling is
untouched.

## Tests

**254 passing**, `FAIL 0`, with 31 skips (the pre-existing credential-gated ones).
`tests/testthat/test-request-assembly.R` is new and covers all five.
